### PR TITLE
Add graph subcommand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ pub fn parse_graph_stages(path: &PathBuf) -> Result<(), PestError<Rule>> {
     use std::fs::File;
     use std::io::Read;
 
-
     match File::open(path) {
         Ok(mut file) => {
             let mut contents = String::new();
@@ -94,13 +93,13 @@ fn stage_graphs(buffer: &str) -> Result<Vec<&str>, PestError<Rule>> {
     fn get_stage_names(pairs: Pairs<Rule>) -> impl Iterator<Item = &str> + '_ {
         pairs.flat_map(|stage| {
             if let Rule::stage = stage.as_rule() {
-                if let Some(stage_name_span)  = stage.into_inner().next() {
+                if let Some(stage_name_span) = stage.into_inner().next() {
                     let stage_name = stage_name_span.as_str();
-                    return Some(&stage_name[1..stage_name.len()-1]);
+                    return Some(&stage_name[1..stage_name.len() - 1]);
                 }
                 return None;
             }
-            return None
+            return None;
         })
     }
 
@@ -112,16 +111,15 @@ fn stage_graphs(buffer: &str) -> Result<Vec<&str>, PestError<Rule>> {
             pest::Position::from_start(buffer),
         ));
     }
-    
+
     let parser = PipelineParser::parse(Rule::pipeline, buffer)?;
-    if let Some(a) = parser.flat_map(|parsed| {
-        match parsed.as_rule() {
-            Rule::stagesDecl => {
-                Some(get_stage_names(parsed.into_inner()))
-            }
-            _ => None
-        }
-    }).next() {
+    if let Some(a) = parser
+        .flat_map(|parsed| match parsed.as_rule() {
+            Rule::stagesDecl => Some(get_stage_names(parsed.into_inner())),
+            _ => None,
+        })
+        .next()
+    {
         return Ok(a.collect::<Vec<_>>());
     } else {
         return Err(PestError::new_from_pos(

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ enum Command {
     #[options(help = "Validate the syntax of a Jenkinsfile")]
     Check(CheckOpts),
     #[options(help = "Print the stages graph of a Jenkinsfile")]
-    Graph(GraphOpts)
+    Graph(GraphOpts),
 }
 
 // Options accepted for the `make` command
@@ -37,7 +37,6 @@ struct GraphOpts {
     #[options(free, required, help = "Path to a Jenkinsfile")]
     file: std::path::PathBuf,
 }
-
 
 /// The number of lines of context to show for errors
 const LINES_OF_CONTEXT: usize = 4;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ struct JdpOptions {
 enum Command {
     #[options(help = "Validate the syntax of a Jenkinsfile")]
     Check(CheckOpts),
+    #[options(help = "Print the stages graph of a Jenkinsfile")]
+    Graph(GraphOpts)
 }
 
 // Options accepted for the `make` command
@@ -27,6 +29,15 @@ struct CheckOpts {
     #[options(free, required, help = "Path to a Jenkinsfile")]
     file: std::path::PathBuf,
 }
+
+#[derive(Debug, Options)]
+struct GraphOpts {
+    #[options(help = "print help message")]
+    help: bool,
+    #[options(free, required, help = "Path to a Jenkinsfile")]
+    file: std::path::PathBuf,
+}
+
 
 /// The number of lines of context to show for errors
 const LINES_OF_CONTEXT: usize = 4;
@@ -108,6 +119,11 @@ fn main() {
                 std::process::exit(1);
             } else {
                 println!("Looks valid! Great work!");
+            }
+        }
+        Command::Graph(graphopts) => {
+            if let Err(_) = parse_graph_stages(&graphopts.file) {
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
## What

Implemented graph subcommand.

See. #12

## How to check operation

1. Run `echo "pipeline{ agent any stages { stage('Build') { steps { sh 'printenv' }} stage('Test') { steps { sh 'cargo test' } } stage('Publish') { steps { sh 'cargo publish' } } }}" > Jenkinsfile`
2. Run `cargo run -q -- graph ./Jenkinsfile | dot -Tpng > pipeline.png`
